### PR TITLE
Change - Set profile_mode to manual

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,9 @@ class tuned (
         '/etc/tuned/active_profile':
             content => "${profile}\n",
             ;
+        '/etc/tuned/profile_mode':
+            content => "manual\n",
+            ;
     }
 
     service { $service:


### PR DESCRIPTION
By default tuned uses dynamic profile mode which causes a conflict
when puppet attempts to change the profile mode.  To avoid this the
/etc/tuned/profile_mode file must be set to manual.